### PR TITLE
Add stronger constraints for database integrity

### DIFF
--- a/scripts/db.sql
+++ b/scripts/db.sql
@@ -62,7 +62,8 @@ CREATE TABLE [dbo].[Result] (
     FOREIGN KEY (FixtureID) REFERENCES [dbo].Fixture(FixtureID),
 
     CONSTRAINT ChkPositiveGoalsFor CHECK ([GoalsFor] >= 0),
-    CONSTRAINT ChkPositiveGoalsAgainst CHECK ([GoalsAgainst] >= 0)
+    CONSTRAINT ChkPositiveGoalsAgainst CHECK ([GoalsAgainst] >= 0),
+    CONSTRAINT UniqueFixtureConstraint UNIQUE (FixtureID)
 );
 
 CREATE TABLE [dbo].[PlayerFixtureStats] (
@@ -81,6 +82,7 @@ CREATE TABLE [dbo].[PlayerFixtureStats] (
     FOREIGN KEY (PlayerID) REFERENCES [dbo].Player(PlayerID),
     FOREIGN KEY (FixtureID) REFERENCES [dbo].Fixture(FixtureID),
 
+    CONSTRAINT UniqueFixturePlayerConstraint UNIQUE (PlayerID, FixtureID),
     CONSTRAINT ChkPositiveSaves CHECK ([Saves] >= 0),
     CONSTRAINT ChkPositiveAssists CHECK ([Assists] >= 0),
     CONSTRAINT ChkPositiveGoals CHECK ([Goals] >= 0),


### PR DESCRIPTION
This improvement ensures that: 
- Every Result belongs to only one Fixture
- Every PlayerStat belongs to a unique combination of a player and a match